### PR TITLE
Move to target_sources CMake directive.

### DIFF
--- a/comms/environmentcontroller/CMakeLists.txt
+++ b/comms/environmentcontroller/CMakeLists.txt
@@ -4,23 +4,17 @@ set(LIB_NAME ${PROJ_NAME}_lib)
 
 find_package(Boost 1.30.0 COMPONENTS program_options REQUIRED)
 
-set(LIB_SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontroller.cpp
-    )
-
-set(LIB_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontroller.h
-    )
-
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-    )
-
-add_executable(${PROJ_NAME} ${SOURCE})
-add_library(${LIB_NAME} STATIC ${LIB_SOURCE} ${LIB_HEADERS})
-
-# Compile Definitions
+add_executable(${PROJ_NAME} "")
 target_compile_definitions(${PROJ_NAME} PRIVATE BOOST_ALL_DYN_LINK)
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+
+add_library(${LIB_NAME} STATIC "")
+set_target_properties(${LIB_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${LIB_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontroller.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontroller.h)
 
 # Include Directories
 target_include_directories(${PROJ_NAME} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/comms/environmentcontroller/CMakeLists.txt
+++ b/comms/environmentcontroller/CMakeLists.txt
@@ -4,26 +4,26 @@ set(LIB_NAME ${PROJ_NAME}_lib)
 
 find_package(Boost 1.30.0 COMPONENTS program_options REQUIRED)
 
-add_executable(${PROJ_NAME} "")
-target_compile_definitions(${PROJ_NAME} PRIVATE BOOST_ALL_DYN_LINK)
-set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_sources(${PROJ_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-
-
+# Library
 add_library(${LIB_NAME} STATIC "")
+target_compile_features(${LIB_NAME} PRIVATE cxx_std_11)
 set_target_properties(${LIB_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${LIB_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontroller.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontroller.h)
-
-# Include Directories
-target_include_directories(${PROJ_NAME} PRIVATE ${Boost_INCLUDE_DIRS})
-
-# Link Libraries
 target_link_libraries(${LIB_NAME} PUBLIC re_common_proto_environmentcontrol)
 target_link_libraries(${LIB_NAME} PUBLIC zmq_protorequester)
 target_link_libraries(${LIB_NAME} PUBLIC re_graphml_parser_lib)
 
+# Executable
+add_executable(${PROJ_NAME} "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
+target_compile_definitions(${PROJ_NAME} PRIVATE BOOST_ALL_DYN_LINK)
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_sources(${PROJ_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+target_include_directories(${PROJ_NAME} PRIVATE ${Boost_INCLUDE_DIRS})
 target_link_libraries(${PROJ_NAME} PUBLIC ${LIB_NAME})
 target_link_libraries(${PROJ_NAME} PRIVATE ${Boost_PROGRAM_OPTIONS_LIBRARY})
 

--- a/comms/environmentrequester/CMakeLists.txt
+++ b/comms/environmentrequester/CMakeLists.txt
@@ -1,16 +1,13 @@
 set(PROJ_NAME zmq_environmentrequester)
 project(${PROJ_NAME})
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/environmentrequester.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/heartbeater.cpp
-    )
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/environmentrequester.h
-    )
-
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/environmentrequester.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/environmentrequester.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/heartbeater.cpp
+        )
 
 # Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC re_common_proto_control)

--- a/comms/environmentrequester/CMakeLists.txt
+++ b/comms/environmentrequester/CMakeLists.txt
@@ -2,13 +2,13 @@ set(PROJ_NAME zmq_environmentrequester)
 project(${PROJ_NAME})
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/environmentrequester.h
         ${CMAKE_CURRENT_SOURCE_DIR}/environmentrequester.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/heartbeater.cpp
         )
-
-# Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC re_common_proto_control)
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protorequester)

--- a/proto/controlmessage/CMakeLists.txt
+++ b/proto/controlmessage/CMakeLists.txt
@@ -6,20 +6,16 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/controlmessage.proto)
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
+target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${PROJ_NAME} PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/helper.cpp
 		${PROTO_HDRS}
 		${PROTO_SRCS}
 		)
-
-# Compile Definitions
-target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
-
-# Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_SOURCE_DIR})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_BINARY_DIR})
-
-# Link Libraries 
 target_link_libraries(${PROJ_NAME} PUBLIC ${PROTOBUF_LIBRARIES})

--- a/proto/controlmessage/CMakeLists.txt
+++ b/proto/controlmessage/CMakeLists.txt
@@ -2,15 +2,16 @@ set(PROJ_NAME re_common_proto_control)
 project(${PROJ_NAME})
 
 find_package(Protobuf REQUIRED)
-
-set(SOURCE
-	${CMAKE_CURRENT_SOURCE_DIR}/helper.cpp
-)
-
 # Generate .proto file
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/controlmessage.proto)
 
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS} ${PROTO_SRCS} ${PROTO_HDRS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/helper.cpp
+		${PROTO_HDRS}
+		${PROTO_SRCS}
+		)
 
 # Compile Definitions
 target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)

--- a/proto/environmentcontrol/CMakeLists.txt
+++ b/proto/environmentcontrol/CMakeLists.txt
@@ -8,18 +8,14 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontrol.proto)
 
 add_library(${PROJ_NAME} STATIC "")
-
-# Compile Definitions
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${PROTO_SRCS}
         ${PROTO_HDRS}
         )
-
-# Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_SOURCE_DIR})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_BINARY_DIR})
-
-# Link Libraries 
 target_link_libraries(${PROJ_NAME} PUBLIC ${PROTOBUF_LIBRARIES})

--- a/proto/environmentcontrol/CMakeLists.txt
+++ b/proto/environmentcontrol/CMakeLists.txt
@@ -7,10 +7,14 @@ find_package(Protobuf REQUIRED)
 # Generate .proto file
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/environmentcontrol.proto)
 
-add_library(${PROJ_NAME} STATIC ${PROTO_SRCS} ${PROTO_HDRS})
+add_library(${PROJ_NAME} STATIC "")
 
 # Compile Definitions
 target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
+target_sources(${PROJ_NAME} PRIVATE
+        ${PROTO_SRCS}
+        ${PROTO_HDRS}
+        )
 
 # Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})

--- a/proto/modelevent/CMakeLists.txt
+++ b/proto/modelevent/CMakeLists.txt
@@ -8,18 +8,14 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/modelevent.proto)
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${PROTO_HDRS}
         ${PROTO_SRCS})
-
-# Compile Definitions
-target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
-
-# Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_SOURCE_DIR})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_BINARY_DIR})
-
-# Link Libraries 
 target_link_libraries(${PROJ_NAME} PUBLIC ${PROTOBUF_LIBRARIES})

--- a/proto/modelevent/CMakeLists.txt
+++ b/proto/modelevent/CMakeLists.txt
@@ -7,7 +7,11 @@ find_package(Protobuf REQUIRED)
 # Generate .proto file
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/modelevent.proto)
 
-add_library(${PROJ_NAME} STATIC ${PROTO_SRCS} ${PROTO_HDRS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+        ${PROTO_HDRS}
+        ${PROTO_SRCS})
 
 # Compile Definitions
 target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)

--- a/proto/systemevent/CMakeLists.txt
+++ b/proto/systemevent/CMakeLists.txt
@@ -7,7 +7,12 @@ find_package(Protobuf REQUIRED)
 # Generate .proto file
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/systemevent.proto)
 
-add_library(${PROJ_NAME} STATIC ${PROTO_SRCS} ${PROTO_HDRS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+        ${PROTO_SRCS}
+        ${PROTO_HDRS}
+        )
 
 # Compile Definitions
 target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)

--- a/proto/systemevent/CMakeLists.txt
+++ b/proto/systemevent/CMakeLists.txt
@@ -8,19 +8,15 @@ find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/systemevent.proto)
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${PROTO_SRCS}
         ${PROTO_HDRS}
         )
-
-# Compile Definitions
-target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
-
-# Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_SOURCE_DIR})
 target_include_directories(${PROJ_NAME} PUBLIC ${RE_COMMON_BINARY_DIR})
-
-# Link Libraries 
 target_link_libraries(${PROJ_NAME} PUBLIC ${PROTOBUF_LIBRARIES})

--- a/util/graphmlparser/CMakeLists.txt
+++ b/util/graphmlparser/CMakeLists.txt
@@ -16,25 +16,21 @@ if(NOT PUGIXML_LIBRARIES)
     return()
 endif()
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/assembly.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/graphmlparser.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/protobufmodelparser.cpp
-)
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/assembly.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/graphmlparser.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/protobufmodelparser.h
-)
-
-add_library(${EXECUTION_PARSER_LIB} STATIC ${SOURCE} ${HEADERS})
-
-add_executable(${EXECUTION_PARSER} "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp")
-
+add_library(${EXECUTION_PARSER_LIB} STATIC "")
+target_sources(${EXECUTION_PARSER_LIB} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/assembly.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/assembly.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/graphmlparser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/graphmlparser.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/protobufmodelparser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/protobufmodelparser.h
+        )
 target_include_directories(${EXECUTION_PARSER_LIB} PRIVATE ${PUGIXML_ROOT}/include)
-
 target_link_libraries(${EXECUTION_PARSER_LIB} PRIVATE ${PUGIXML_LIBRARIES})
 target_link_libraries(${EXECUTION_PARSER_LIB} PUBLIC re_common_proto_control)
 
+add_executable(${EXECUTION_PARSER} "")
 target_link_libraries(${EXECUTION_PARSER} PRIVATE ${EXECUTION_PARSER_LIB})
+target_sources(${EXECUTION_PARSER} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+        )

--- a/util/graphmlparser/CMakeLists.txt
+++ b/util/graphmlparser/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT PUGIXML_LIBRARIES)
 endif()
 
 add_library(${EXECUTION_PARSER_LIB} STATIC "")
+target_compile_features(${EXECUTION_PARSER_LIB} PRIVATE cxx_std_11)
 target_sources(${EXECUTION_PARSER_LIB} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/assembly.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/assembly.h
@@ -30,6 +31,7 @@ target_link_libraries(${EXECUTION_PARSER_LIB} PRIVATE ${PUGIXML_LIBRARIES})
 target_link_libraries(${EXECUTION_PARSER_LIB} PUBLIC re_common_proto_control)
 
 add_executable(${EXECUTION_PARSER} "")
+target_compile_features(${EXECUTION_PARSER} PRIVATE cxx_std_11)
 target_link_libraries(${EXECUTION_PARSER} PRIVATE ${EXECUTION_PARSER_LIB})
 target_sources(${EXECUTION_PARSER} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp

--- a/zmq/protoreceiver/CMakeLists.txt
+++ b/zmq/protoreceiver/CMakeLists.txt
@@ -1,15 +1,12 @@
 set(PROJ_NAME zmq_protoreceiver)
 project (${PROJ_NAME})
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/protoreceiver.cpp
-	)
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/protoreceiver.h
-    )
-
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/protoreceiver.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/protoreceiver.h
+		)
 
 # Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protoregister)

--- a/zmq/protoreceiver/CMakeLists.txt
+++ b/zmq/protoreceiver/CMakeLists.txt
@@ -2,11 +2,11 @@ set(PROJ_NAME zmq_protoreceiver)
 project (${PROJ_NAME})
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${PROJ_NAME} PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/protoreceiver.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/protoreceiver.h
 		)
-
-# Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protoregister)

--- a/zmq/protoregister/CMakeLists.txt
+++ b/zmq/protoregister/CMakeLists.txt
@@ -4,15 +4,12 @@ project (${PROJ_NAME})
 find_package(Protobuf REQUIRED)
 find_package(ZMQ REQUIRED)
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/protoregister.cpp
-)
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/protoregister.hpp
-)
-
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/protoregister.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/protoregister.hpp
+        )
 
 # Compile Definitions
 target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)

--- a/zmq/protoregister/CMakeLists.txt
+++ b/zmq/protoregister/CMakeLists.txt
@@ -5,19 +5,15 @@ find_package(Protobuf REQUIRED)
 find_package(ZMQ REQUIRED)
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/protoregister.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/protoregister.hpp
         )
-
-# Compile Definitions
-target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
-
-# Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${ZMQ_INCLUDE_DIRS})
-
-# Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC ${PROTOBUF_LIBRARIES})
 target_link_libraries(${PROJ_NAME} PUBLIC ${ZMQ_LIBRARIES})

--- a/zmq/protoreplier/CMakeLists.txt
+++ b/zmq/protoreplier/CMakeLists.txt
@@ -2,11 +2,11 @@ set(PROJ_NAME zmq_protoreplier)
 project (${PROJ_NAME})
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/protoreplier.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/protoreplier.hpp
         )
-
-# Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protoregister)

--- a/zmq/protoreplier/CMakeLists.txt
+++ b/zmq/protoreplier/CMakeLists.txt
@@ -1,15 +1,12 @@
 set(PROJ_NAME zmq_protoreplier)
 project (${PROJ_NAME})
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/protoreplier.cpp
-	)
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/protoreplier.hpp
-    )
-
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/protoreplier.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/protoreplier.hpp
+        )
 
 # Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protoregister)

--- a/zmq/protorequester/CMakeLists.txt
+++ b/zmq/protorequester/CMakeLists.txt
@@ -1,20 +1,12 @@
 set(PROJ_NAME zmq_protorequester)
 project (${PROJ_NAME})
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/protorequester.cpp
-	)
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/protorequester.hpp
-    )
-
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${PROJ_NAME} PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/protorequester.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/protorequester.hpp
 		)
-
-# Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protoregister)

--- a/zmq/protorequester/CMakeLists.txt
+++ b/zmq/protorequester/CMakeLists.txt
@@ -9,7 +9,12 @@ set(HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/protorequester.hpp
     )
 
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/protorequester.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/protorequester.hpp
+		)
 
 # Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC zmq_protoregister)

--- a/zmq/protowriter/CMakeLists.txt
+++ b/zmq/protowriter/CMakeLists.txt
@@ -5,19 +5,16 @@ find_package(Boost 1.30.0 COMPONENTS filesystem system REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(ZMQ REQUIRED)
 
-set(SOURCE
-    ${CMAKE_CURRENT_SOURCE_DIR}/protowriter.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cachedprotowriter.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/monitor.cpp
-)
-
-set(HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/protowriter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/cachedprotowriter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/monitor.h
-)
-
-add_library(${PROJ_NAME} STATIC ${SOURCE} ${HEADERS})
+add_library(${PROJ_NAME} STATIC "")
+set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(${PROJ_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/protowriter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/cachedprotowriter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/monitor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/protowriter.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/cachedprotowriter.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/monitor.h
+        )
 
 # Compile Definitions
 target_compile_definitions(${PROJ_NAME} PUBLIC BOOST_ALL_DYN_LINK)

--- a/zmq/protowriter/CMakeLists.txt
+++ b/zmq/protowriter/CMakeLists.txt
@@ -6,7 +6,11 @@ find_package(Protobuf REQUIRED)
 find_package(ZMQ REQUIRED)
 
 add_library(${PROJ_NAME} STATIC "")
+target_compile_features(${PROJ_NAME} PRIVATE cxx_std_11)
+target_compile_definitions(${PROJ_NAME} PUBLIC BOOST_ALL_DYN_LINK)
+target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
 set_target_properties(${PROJ_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_sources(${PROJ_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/protowriter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/cachedprotowriter.cpp
@@ -15,17 +19,10 @@ target_sources(${PROJ_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/cachedprotowriter.h
         ${CMAKE_CURRENT_SOURCE_DIR}/monitor.h
         )
-
-# Compile Definitions
-target_compile_definitions(${PROJ_NAME} PUBLIC BOOST_ALL_DYN_LINK)
-target_compile_definitions(${PROJ_NAME} PUBLIC PROTOBUF_USE_DLLS)
-
-# Include Directories
 target_include_directories(${PROJ_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 target_include_directories(${PROJ_NAME} PUBLIC ${ZMQ_INCLUDE_DIRS})
 
-# Link Libraries
 target_link_libraries(${PROJ_NAME} PUBLIC ${PROTOBUF_LIBRARIES})
 target_link_libraries(${PROJ_NAME} PUBLIC ${ZMQ_LIBRARIES})
 target_link_libraries(${PROJ_NAME} PUBLIC ${Boost_SYSTEM_LIBRARY})


### PR DESCRIPTION
Explicitly build targets with fPIC enabled.